### PR TITLE
Feature: Add app name support to branch naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "branch-creator" extension will be documented in this
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.0.9] - YYYY-MM-DD
+
+### Added
+- **App Name Support in Branch Naming**: Introduced the ability to include app names in branch names, configurable through the new `branch-creator.appsList` and `branch-creator.appFirst` settings. This addition offers enhanced flexibility and organization for managing branches in projects with multiple apps.
+
+### Changed
+- Improved branch naming logic to support conditional inclusion of app names, based on user preferences set in `branch-creator.appsList` and `branch-creator.appFirst`. This allows users to specify whether app names should precede the branch prefix or be integrated into the usual branch naming format.
+
 ## [0.0.8] - 2024-02-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The Git Branch Creator extension simplifies the process of creating and switchin
 - **Flexible Repository Selection:** Works with both the root workspace and subfolder Git repositories.
 - **Customizable Branch Prefixes:** Configure branch prefixes to match your project's naming conventions for creating new branches.
 - **Configurable Branch Name Separator:** Customize the separator used in branch names to fit your team's standards.
+- **App Name Inclusion in Branch Names:** Provides the option to include app names in branch names, either at the beginning or integrated within the standard branch naming convention. This feature enhances organization and clarity for projects with multiple applications.
 - **Interactive Branch Creation:** Guides you through each step of the branch creation process with intuitive prompts.
 - **Efficient Branch Switching:** Easily switch between existing local branches with a simple selection from a list, including handling multiple repositories by showing branches common to all.
 - **Branch Naming Validation:** Allows you to validate the naming of all your branches against configured prefixes and a whitelist of branch names. This ensures adherence to your project's branching conventions.
@@ -24,6 +25,9 @@ This extension contributes the following settings:
 - `branch-creator.branchNameSeparator`: The separator used in branch names. Default is `-`.
 - `branch-creator.validateWhiteList`: List of whitelist branch names that should not be validated. Defaults include `["master", "main", "develop", "staging", "HEAD -> origin/master"]`.
 - `branch-creator.isTicketNumberMust`: Specifies whether including a ticket number is mandatory for branch naming. Default is `true`. If set to `false`, branches can be created without specifying a ticket number.
+- `branch-creator.appsList`: An array of app names for inclusion in branch names. This allows for branches to be categorized by app name for projects spanning multiple applications. Default is an empty array, indicating no app name inclusion.
+- `branch-creator.appFirst`: A boolean setting that determines if the app name should be placed at the beginning of the branch name when `appsList` is used. This is useful for prioritizing app names in branch categorization. Default is `false`.
+
 
 ## Installation
 
@@ -69,7 +73,12 @@ Alternatively, you can modify your `settings.json` directly:
   "branch-creator.prefixes": ["feature", "hotfix", "bugfix", "release"],
   "branch-creator.branchNameSeparator": "_",
   "branch-creator.validateWhiteList": ["master", "main", "develop", "staging", "HEAD -> origin/master"],
-   "branch-creator.isTicketNumberMust": false
+   "branch-creator.isTicketNumberMust": false,
+    "branch-creator.appsList": [
+        "API",
+        "SDK"
+    ],
+    "branch-creator.appFirst": false,
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,16 @@
           ],
           "description": "List of prefixes for branch names."
         },
+        "branch-creator.appsList": {
+            "type": "array",
+            "default": [],
+            "description": "A list of possible app names to include in the branch name. Leave empty if not used."
+        },
+        "branch-creator.appFirst": {
+            "type": "boolean",
+            "default": false,
+            "description": "Determines if the app name should be placed at the beginning of the branch name. Applicable only if 'appsList' is not empty."
+        },
         "branch-creator.validateWhiteList": {
           "type": "array",
           "default": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,3 +49,16 @@ export function defaultSwitchAndPull(): boolean {
 export function getValidateBranchNameWhiteList(): string[] {
     return getConfig<string[]>('validateWhiteList', []);
 }
+
+export function getAppListFromConfig(): string[] {
+    return getConfig<string[]>('appList', []);
+}
+
+export function getIsAppFirstFromConfig(): boolean {
+    return getConfig<boolean>('isAppFirst', false);
+}
+
+// TODO: rename this to getIsTicketNumberRequired
+export function getIsTicketNumberMustFromConfig(): boolean {
+    return getConfig<boolean>('isTicketNumberMust', false);
+}


### PR DESCRIPTION
- Implemented support for including app names in branch names, enhancing project organization for multi-app developments.
- Added `appsList` and `appFirst` settings to allow users to configure app name inclusion and positioning within branch names.
- Updated README and CHANGELOG to document the new features and settings, providing clear guidance on how to utilize app name support in branch naming conventions.

This update offers users increased flexibility in customizing branch names to reflect app-specific workflows, improving clarity and navigability across projects.